### PR TITLE
Buttonコンポーネントの作成

### DIFF
--- a/src/components/atoms/Button/Button.styles.ts
+++ b/src/components/atoms/Button/Button.styles.ts
@@ -1,0 +1,28 @@
+import styled, { CSSObject } from '@emotion/styled';
+import theme from '@/themes/theme';
+
+const { spacing, colors } = theme;
+const { text, primary } = colors;
+
+const buttonStyles: CSSObject = {
+  color: text.white,
+  padding: `${spacing(0.5)} ${spacing(2)}`,
+  borderRadius: `${spacing(0.5)}`,
+  border: 'none',
+};
+
+// 状態に応じたスタイリングを返す
+const getActiveStyle = (disabled: boolean): CSSObject => ({
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  backgroundColor: disabled ? primary.disabled : primary.main,
+  '&:hover': {
+    backgroundColor: disabled ? primary.disabled : primary.light,
+  },
+});
+
+const StyledButton = styled.button<{ disabled: boolean }>(({ disabled }) => ({
+  ...buttonStyles,
+  ...getActiveStyle(disabled),
+}));
+
+export default StyledButton;

--- a/src/components/atoms/Button/Button.test.tsx
+++ b/src/components/atoms/Button/Button.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import theme from '@/themes/theme';
+import Button from './Button';
+
+describe('Button', () => {
+  const buttonLabel = 'Click me';
+  const handleClick = jest.fn();
+
+  beforeEach(() => {
+    handleClick.mockClear();
+  });
+
+  // childrenプロップが正しく反映されるか
+  it('renders the button with children', () => {
+    render(<Button onClick={handleClick}>{buttonLabel}</Button>);
+    const buttonElement = screen.getByText(buttonLabel);
+    expect(buttonElement).toBeVisible();
+  });
+
+  // onClickが正常に動作しているか
+  it('calls onClick when clicked', () => {
+    render(<Button onClick={handleClick}>{buttonLabel}</Button>);
+    const buttonElement = screen.getByText(buttonLabel);
+    fireEvent.click(buttonElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  // disabledがtrueの時にonClickイベントが呼ばれないこと
+  it('does not call onClick when disabled', () => {
+    render(
+      <Button onClick={handleClick} disabled>
+        {buttonLabel}
+      </Button>
+    );
+    const buttonElement = screen.getByText(buttonLabel);
+    fireEvent.click(buttonElement);
+    expect(handleClick).toHaveBeenCalledTimes(0);
+  });
+
+  // disabledがtrueの状態でのスタイルを確認
+  it('has disabled styles when disabled', () => {
+    render(
+      <Button onClick={() => {}} disabled>
+        {buttonLabel}
+      </Button>
+    );
+    const buttonElement = screen.getByText(buttonLabel);
+    expect(buttonElement).toHaveAttribute('disabled');
+    expect(buttonElement).toHaveStyle('cursor: not-allowed');
+    expect(buttonElement).toHaveStyle(`background-color: ${theme.colors.primary.disabled}`);
+  });
+});

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import StyledButton from './Button.styles';
+import { ButtonProps } from './Button.types';
+
+const Button: React.FC<ButtonProps> = ({ children, onClick, disabled = false }) => {
+  return (
+    <StyledButton onClick={onClick} disabled={disabled}>
+      {children}
+    </StyledButton>
+  );
+};
+
+export default Button;

--- a/src/components/atoms/Button/Button.types.ts
+++ b/src/components/atoms/Button/Button.types.ts
@@ -1,0 +1,6 @@
+export interface ButtonProps {
+  disabled?: boolean;
+  // NOTE:アイコンボタン付きのボタン等に対応するためlabe:stringのようにしない
+  children: React.ReactNode;
+  onClick: () => void;
+}

--- a/src/themes/config/colors.ts
+++ b/src/themes/config/colors.ts
@@ -1,9 +1,9 @@
 const colors = {
   primary: {
+    disabled: '#b3d1ff',
     light: '#63a4ff',
     main: '#1976d2',
     dark: '#004ba0',
-    contrastText: '#fff',
   },
   background: {
     default: '#f5f5f5',
@@ -13,6 +13,7 @@ const colors = {
     primary: '#333',
     secondary: '#888',
     disabled: '#bbb',
+    white: '#fff',
   },
 };
 


### PR DESCRIPTION
## チケット

ref #3 
closes #6 

## 概要

`atoms`ディレクトリに`Button`コンポーネントを作成する。
作成したコンポーネントに対してテストコードを作成して実行する。

## 変更点・機能追加
### `Button`コンポーネントを作成
渡せるpropsは以下。
```ts
export interface ButtonProps {
  disabled?: boolean;
  children: React.ReactNode;
  onClick: () => void;
}
```

### `Button.test.tsx`ファイルを作成してテストを実行
Jest、testing-libraryでテストを実行。

## テスト

- [x] `children`に値を代入して適切に反映されること
- [x] `onClick`が正常に動作すること
- [x] disabledがtrueの時にonClickイベントが呼ばれないこと
- [x] disabledがtrueの状態でのスタイルが付与されていること

## 確認事項

- [x] テストがパスするか 

## スクリーンショット
<details><summary>Buttonコンポーネントのテスト結果</summary>
<p>

![Buttonコンポーネントのテスト結果](https://github.com/user-attachments/assets/eef95310-792b-4f2d-ae10-9682849e3f44)


</p>
</details> 
