### PR TITLE
Checkboxコンポーネントを作成

### DIFF
--- a/src/components/atoms/Checkbox/Checkbox.styles.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.styles.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import theme from '@/themes/theme';
+
+const { spacing, colors } = theme;
+
+export const CheckboxContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  margin: spacing(1),
+});
+
+export const CheckboxInput = styled.input({
+  accentColor: colors.primary.main,
+  cursor: 'pointer',
+});
+
+export const Label = styled.label({
+  marginLeft: spacing(1),
+  cursor: 'pointer',
+});

--- a/src/components/atoms/Checkbox/Checkbox.test.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Checkbox from './Checkbox';
+
+describe('Checkbox', () => {
+  const testLabel = 'Test Checkbox';
+  const testId = 'test-checkbox';
+  let mockOnChange: jest.Mock;
+
+  beforeEach(() => {
+    mockOnChange = jest.fn();
+  });
+
+  const renderCheckbox = (checked: boolean) =>
+    render(<Checkbox id={testId} label={testLabel} checked={checked} onChange={mockOnChange} />);
+
+  // チェックボックスとそのラベルが正しく表示されるか
+  it('renders the Checkbox with the correct label', () => {
+    renderCheckbox(false);
+    const checkboxElement = screen.getByLabelText(testLabel);
+    expect(checkboxElement).toBeVisible();
+    expect(checkboxElement).toBeInstanceOf(HTMLInputElement);
+  });
+
+  // チェックプロップがtrueのとき、チェックボックスが正しくチェック状態になるか
+  it('renders the Checkbox as checked when checked prop is true', () => {
+    renderCheckbox(true);
+    const checkboxElement = screen.getByLabelText(testLabel);
+    expect(checkboxElement).toBeChecked();
+  });
+
+  // チェックプロップがfalseのとき、チェックボックスがチェックされていない状態で表示されるか
+  it('renders the Checkbox as unchecked when checked prop is false', () => {
+    renderCheckbox(false);
+    const checkboxElement = screen.getByLabelText(testLabel);
+    expect(checkboxElement).not.toBeChecked();
+  });
+
+  // チェックボックスをクリックした際にonChangeが正しく呼び出されるか
+  it('triggers onChange when the Checkbox clicked', () => {
+    renderCheckbox(false);
+    const checkboxElement = screen.getByLabelText(testLabel);
+    fireEvent.click(checkboxElement);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  // ラベルをクリックした際にonChangeが正しく呼び出されるか
+  it('triggers onChange when the label is clicked', () => {
+    renderCheckbox(false);
+    const labelElement = screen.getByText(testLabel);
+    fireEvent.click(labelElement);
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/atoms/Checkbox/Checkbox.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.tsx
@@ -1,0 +1,13 @@
+import { CheckboxContainer, CheckboxInput, Label } from './Checkbox.styles';
+import { CheckboxProps } from './Checkbox.types';
+
+const Checkbox: React.FC<CheckboxProps> = ({ id, label, checked, onChange }) => {
+  return (
+    <CheckboxContainer>
+      <CheckboxInput type='checkbox' id={id} checked={checked} onChange={onChange} />
+      <Label htmlFor={id}>{label}</Label>
+    </CheckboxContainer>
+  );
+};
+
+export default Checkbox;

--- a/src/components/atoms/Checkbox/Checkbox.types.ts
+++ b/src/components/atoms/Checkbox/Checkbox.types.ts
@@ -1,0 +1,6 @@
+export interface CheckboxProps {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+}


### PR DESCRIPTION
## チケット

ref #3 
closes #7 

## 概要

`atoms`ディレクトリに`Checkbox`コンポーネントを作成する。
作成したコンポーネントに対してテストコードを作成して実行する。

## 変更点・機能追加
### `Checkbox`コンポーネントを作成
渡せるpropsは以下。
```ts
export interface CheckboxProps {
  id: string;
  label: string;
  checked: boolean;
  onChange: () => void;
}
```

### `Checkbox.test.tsx`ファイルを作成してテストを実行
Jest、testing-libraryでテストを実行。

## テスト

- [x] チェックボックスとそのラベルが正しく表示されること
- [x] チェックプロップがtrueのとき、チェックボックスが正しくチェック状態になること
- [x] チェックプロップがfalseのとき、チェックボックスがチェックされていない状態で表示されること
- [x] チェックボックスをクリックした際にonChangeが正しく呼び出されること
- [x] ラベルをクリックした際にonChangeが正しく呼び出されること


## 確認事項

- [x] テストがパスするか 

## スクリーンショット
<details><summary>Checkboxコンポーネントのテスト結果</summary>
<p>

![Checkboxコンポーネントのテスト結果](https://github.com/user-attachments/assets/840e79f3-483a-4ac6-b3b8-bc5fd517b0ed)


</p>
</details> 
