### PR TITLE
Tabコンポーネントの作成

### DIFF
--- a/src/components/atoms/Tab/Tab.styles.ts
+++ b/src/components/atoms/Tab/Tab.styles.ts
@@ -1,0 +1,28 @@
+import styled, { CSSObject } from '@emotion/styled';
+import theme from '@/themes/theme';
+
+const { spacing, colors } = theme;
+const { primary, background, text } = colors;
+
+const tabStyles: CSSObject = {
+  border: 'none',
+  padding: `${spacing(1)}`,
+  minWidth: spacing(12),
+  borderTopRightRadius: spacing(1),
+  borderTopLeftRadius: spacing(1),
+};
+
+// 状態に応じたスタイリングを返す
+const getActiveTabStyle = (selected: boolean): CSSObject => ({
+  cursor: selected ? 'default' : 'pointer',
+  color: selected ? text.white : text.primary,
+  backgroundColor: selected ? primary.main : background.grey,
+  '&:hover': {
+    backgroundColor: selected ? primary.main : background.lightgrey,
+  },
+});
+
+export const StyledTab = styled.button<{ selected: boolean }>(({ selected }) => ({
+  ...tabStyles,
+  ...getActiveTabStyle(selected),
+}));

--- a/src/components/atoms/Tab/Tab.test.tsx
+++ b/src/components/atoms/Tab/Tab.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import theme from '@/themes/theme';
+import Tab from './Tab';
+import '@testing-library/jest-dom';
+
+describe('Tab', () => {
+  const tabLabel = 'Test Tab';
+  const handleClick = jest.fn();
+  const { background, text } = theme.colors;
+
+  beforeEach(() => {
+    handleClick.mockClear();
+  });
+
+  // Tabのラベルが正しく反映しているか
+  it('renders the tab with the correct label', () => {
+    render(<Tab label={tabLabel} selected={false} onClick={() => {}} />);
+    const tabElement = screen.getByText(tabLabel);
+    expect(tabElement).toBeVisible();
+  });
+
+  // onClickが正常に動作しているか
+  it('calls onClick when clicked', () => {
+    render(<Tab label={tabLabel} selected={false} onClick={handleClick} />);
+    const buttonElement = screen.getByText(tabLabel);
+    fireEvent.click(buttonElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  // selectedがtrueの場合のスタイルをテスト
+  it('test styles when selected is true', () => {
+    render(<Tab label={tabLabel} selected={true} onClick={handleClick} />);
+    const buttonElement = screen.getByText(tabLabel);
+    expect(buttonElement).toHaveStyle({
+      cursor: 'default',
+      color: text.white,
+    });
+  });
+
+  // selectedがfalseの場合のスタイルをテスト
+  it('test no-selected styles when selected is false', () => {
+    render(<Tab label={tabLabel} selected={false} onClick={handleClick} />);
+    const buttonElement = screen.getByText(tabLabel);
+    expect(buttonElement).toHaveStyle({
+      cursor: 'pointer',
+      color: text.primary,
+    });
+  });
+
+  // Hover時のスタイルをテスト
+  it('hover styles when not selected and hovered', () => {
+    render(<Tab label={tabLabel} selected={false} onClick={handleClick} />);
+    const buttonElement = screen.getByText(tabLabel);
+    fireEvent.mouseOver(buttonElement);
+    expect(buttonElement).toHaveStyle({
+      backgroundColor: background.lightgrey,
+    });
+  });
+});

--- a/src/components/atoms/Tab/Tab.tsx
+++ b/src/components/atoms/Tab/Tab.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { StyledTab } from './Tab.styles';
+import { TabProps } from './Tab.types';
+
+const Tab: React.FC<TabProps> = ({ label, selected, onClick }) => {
+  return (
+    <StyledTab selected={selected} onClick={onClick}>
+      {label}
+    </StyledTab>
+  );
+};
+
+export default Tab;

--- a/src/components/atoms/Tab/Tab.types.tsx
+++ b/src/components/atoms/Tab/Tab.types.tsx
@@ -1,0 +1,5 @@
+export interface TabProps {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}

--- a/src/themes/config/colors.ts
+++ b/src/themes/config/colors.ts
@@ -6,6 +6,8 @@ const colors = {
     dark: '#004ba0',
   },
   background: {
+    grey: '#bbb',
+    lightgrey: '#d7d7d7',
     default: '#f5f5f5',
     paper: '#fff',
   },


### PR DESCRIPTION
## チケット

ref #3 
closes #8 

## 概要

`atoms`ディレクトリに`Tab`コンポーネントを作成する。
作成したコンポーネントに対してテストコードを作成して実行する。

## 変更点・機能追加
### `Tab`コンポーネントを作成
渡せるpropsは以下。
```ts
export interface TabProps {
  label: string;
  selected: boolean;
  onClick: () => void;
}
```

### `Tab.test.tsx`ファイルを作成してテストを実行
Jest、testing-libraryでテストを実行。

## テスト

- [x] Tabのラベルが正しく反映していること
- [x] onClickが正常に動作していること
- [x] selectedがtrueの場合のスタイル
- [x] selectedがfalseの場合のスタイル
- [x] Hover時のスタイル


## 確認事項

- [x] テストがパスするか 

## スクリーンショット
<details><summary>Tabコンポーネントのテスト結果</summary>
<p>

![Tabコンポーネントのテスト結果](https://github.com/user-attachments/assets/d1f91f8c-f590-4b96-bef7-58bcbda14066)


</p>
</details> 
