### PR TITLE
Headerコンポーネントの作成/Storyの作成/テスト実行

### DIFF
--- a/jest.molecules.config.ts
+++ b/jest.molecules.config.ts
@@ -1,0 +1,12 @@
+import nextJest from 'next/jest';
+import createConfig from './jest/createConfig';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const atomComponentJestConfig = {
+  ...createConfig('molecules'),
+};
+
+export default createJestConfig(atomComponentJestConfig);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check-lint": "eslint . --ext ts --ext tsx --ext js",
     "check-all": "npm run check-format && npm run check-lint && npm run check-types",
     "test:atoms": "jest --config jest.atoms.config.ts",
+    "test:molecules": "jest --config jest.molecules.config.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/components/atoms/Typography/Typography.test.tsx
+++ b/src/components/atoms/Typography/Typography.test.tsx
@@ -17,7 +17,7 @@ describe('Typography Component', () => {
     render(<Typography variant='h1' text='Heading Text' />);
     const element = screen.getByText(/Heading Text/i);
     expect(element).toBeInTheDocument();
-    expect(element.tagName).toBe('H1'); // 指定したタグでレンダリング
+    expect(element.tagName).toBe('H1');
   });
 
   // boldプロパティがtrueのとき、太字のスタイルが適用されることを確認
@@ -25,7 +25,7 @@ describe('Typography Component', () => {
     render(<Typography text='Bold Text' bold={true} />);
     const element = screen.getByText(/Bold Text/i);
     expect(element).toBeInTheDocument();
-    expect(element).toHaveClass(styles.textBold); // styles.textBold が適用されることを確認
+    expect(element).toHaveClass(styles.textBold);
   });
 
   // boldプロパティがfalseのとき、太字のスタイルが適用されないことを確認
@@ -33,6 +33,6 @@ describe('Typography Component', () => {
     render(<Typography text='Regular Text' bold={false} />);
     const element = screen.getByText(/Regular Text/i);
     expect(element).toBeInTheDocument();
-    expect(element).not.toHaveClass(styles.textBold); // styles.textBold が適用されないことを確認
+    expect(element).not.toHaveClass(styles.textBold);
   });
 });

--- a/src/components/molecules/Header/Header.module.scss
+++ b/src/components/molecules/Header/Header.module.scss
@@ -1,0 +1,14 @@
+@use '../../../styles/variables/colors' as color;
+@use '../../../styles/variables/spacing' as spacing;
+
+.header {
+  background-color: color.$primary-main;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+  padding: spacing.$xs;
+
+  h5 {
+    color: color.$text-white;
+  }
+}

--- a/src/components/molecules/Header/Header.stories.tsx
+++ b/src/components/molecules/Header/Header.stories.tsx
@@ -1,0 +1,18 @@
+import Header from './Header';
+import { HeaderProps } from './Header.types';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<HeaderProps> = {
+  title: 'molecules/Header',
+  component: Header,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    title: 'Header Title',
+  },
+};

--- a/src/components/molecules/Header/Header.test.tsx
+++ b/src/components/molecules/Header/Header.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import Header from './Header';
+import styles from './Header.module.scss';
+import '@testing-library/jest-dom';
+
+describe('Header Component', () => {
+  // タイトルが正しく表示されることを確認
+  it('renders with the given title', () => {
+    render(<Header title='Test Title' />);
+    const titleElement = screen.getByText(/Test Title/i);
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  // Headerのスタイルが正しく適用されていることを確認
+  it('has the correct header class', () => {
+    const { container } = render(<Header title='Test Title' />);
+    const headerElement = container.querySelector('header');
+    expect(headerElement).toHaveClass(styles.header);
+  });
+});

--- a/src/components/molecules/Header/Header.tsx
+++ b/src/components/molecules/Header/Header.tsx
@@ -1,0 +1,15 @@
+import Typography from '../../atoms/Typography/Typography';
+import styles from './Header.module.scss';
+import { HeaderProps } from './Header.types';
+
+const Header: React.FC<HeaderProps> = ({ title }) => {
+  const headerStyle = `${styles.header}`;
+
+  return (
+    <header className={headerStyle}>
+      <Typography variant='h5' text={title} />
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/molecules/Header/Header.types.ts
+++ b/src/components/molecules/Header/Header.types.ts
@@ -1,0 +1,3 @@
+export interface HeaderProps {
+  title: string;
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -7,7 +7,6 @@
 
 * {
   color: color.$text-default;
-  background-color: color.$background-default;
 }
 
 html {
@@ -20,6 +19,7 @@ html {
 body {
   font-family: 'Roboto', sans-serif;
   line-height: font.$line-height-base;
+  background-color: color.$background-default;
 }
 
 h1 {


### PR DESCRIPTION
## チケット

closes #25 

## 概要

- アプリ画面のヘッダのための`Header`コンポーネントを作成。
- 他のmoleculeコンポーネントで使用するconfig.tsファイルを作成

## 変更点・機能追加

### globals.scssのスタイル変更

全体(*)に対して`background-color`を指定していたが、bodyタグに対して`background-color`を指定し直す。

### HeaderコンポーネントとそのStoryを作成

atoms/で作成した`Typography`コンポーネントを使用
今回のアプリでは、タイトルでのみ`Typography`を使用する。
→`variant = "h5"`として、`Header.scss`にて直接`h5`に`color : color.$text-white`を指定している。
→今後、`color`の指定ができるようにするかは、プロジェクトでの使用頻度に依存させる。

## テスト内容

- [x] タイトルが正しく表示されること
- [x] Headerのスタイルが正しく適用されていること

## 確認事項

- [x] テストがPASSすること
- [x] Storybookで動作確認