### PR TITLE
CheckedManageFrameコンポーネントの作成/Storyの作成/テスト実行

### DIFF
--- a/src/components/atoms/Typography/Typography.test.tsx
+++ b/src/components/atoms/Typography/Typography.test.tsx
@@ -8,7 +8,7 @@ describe('Typography Component', () => {
   it('renders with default paragraph tag and text', () => {
     render(<Typography text='Default Text' />);
     const element = screen.getByText(/Default Text/i);
-    expect(element).toBeInTheDocument();
+    expect(element).toBeVisible();
     expect(element.tagName).toBe('P'); // デフォルトは <p> タグ
   });
 
@@ -16,7 +16,7 @@ describe('Typography Component', () => {
   it('renders with specified heading tag', () => {
     render(<Typography variant='h1' text='Heading Text' />);
     const element = screen.getByText(/Heading Text/i);
-    expect(element).toBeInTheDocument();
+    expect(element).toBeVisible();
     expect(element.tagName).toBe('H1');
   });
 
@@ -24,7 +24,7 @@ describe('Typography Component', () => {
   it('renders bold text when bold prop is true', () => {
     render(<Typography text='Bold Text' bold={true} />);
     const element = screen.getByText(/Bold Text/i);
-    expect(element).toBeInTheDocument();
+    expect(element).toBeVisible();
     expect(element).toHaveClass(styles.textBold);
   });
 
@@ -32,7 +32,7 @@ describe('Typography Component', () => {
   it('does not render bold text when bold prop is false', () => {
     render(<Typography text='Regular Text' bold={false} />);
     const element = screen.getByText(/Regular Text/i);
-    expect(element).toBeInTheDocument();
+    expect(element).toBeVisible();
     expect(element).not.toHaveClass(styles.textBold);
   });
 });

--- a/src/components/molecules/CheckedManageFrame/CheckedManageFrame.module.scss
+++ b/src/components/molecules/CheckedManageFrame/CheckedManageFrame.module.scss
@@ -1,0 +1,6 @@
+.frame {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 13rem;
+}

--- a/src/components/molecules/CheckedManageFrame/CheckedManageFrame.stories.tsx
+++ b/src/components/molecules/CheckedManageFrame/CheckedManageFrame.stories.tsx
@@ -1,0 +1,20 @@
+import { fn } from '@storybook/test';
+import CheckedManageFrame from './CheckedManageFrame';
+import { CheckedManageFrameProps } from './CheckedManageFrame.types';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<CheckedManageFrameProps> = {
+  title: 'molecules/CheckedManageFrame',
+  component: CheckedManageFrame,
+  tags: ['autodocs'],
+  args: { onReset: fn() },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    checkedSum: 0,
+  },
+};

--- a/src/components/molecules/CheckedManageFrame/CheckedManageFrame.test.tsx
+++ b/src/components/molecules/CheckedManageFrame/CheckedManageFrame.test.tsx
@@ -36,7 +36,6 @@ describe('CheckedManageFrame Component', () => {
 
     const buttonElement = screen.getByRole('button', { name: /選択解除/i });
     buttonElement.click();
-
     expect(mockOnReset).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/molecules/CheckedManageFrame/CheckedManageFrame.test.tsx
+++ b/src/components/molecules/CheckedManageFrame/CheckedManageFrame.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import CheckedManageFrame from './CheckedManageFrame';
+import styles from './CheckedManageFrame.module.scss';
+import '@testing-library/jest-dom';
+
+describe('CheckedManageFrame Component', () => {
+  const mockOnReset = jest.fn();
+
+  // checkedSumが0より大きい場合のテスト
+  it('renders the correct text and enables the button when checkedSum is greater than 0', () => {
+    render(<CheckedManageFrame checkedSum={5} onReset={mockOnReset} />);
+
+    const textElement = screen.getByText(/選択件数：5件/i);
+    expect(textElement).toBeVisible();
+
+    const buttonElement = screen.getByRole('button', { name: /選択解除/i });
+    expect(buttonElement).toBeVisible();
+    expect(buttonElement).toBeEnabled();
+  });
+
+  // checkedSumが0の場合のテスト
+  it('renders the correct text and disables the button when checkedSum is 0', () => {
+    render(<CheckedManageFrame checkedSum={0} onReset={mockOnReset} />);
+
+    const textElement = screen.getByText(/選択件数：0件/i);
+    expect(textElement).toBeVisible();
+
+    const buttonElement = screen.getByRole('button', { name: /選択解除/i });
+    expect(buttonElement).toBeVisible();
+    expect(buttonElement).toBeDisabled();
+  });
+
+  // ボタンがクリックされたときにonResetが呼ばれることを確認
+  it('calls onReset when the button is clicked', () => {
+    render(<CheckedManageFrame checkedSum={5} onReset={mockOnReset} />);
+
+    const buttonElement = screen.getByRole('button', { name: /選択解除/i });
+    buttonElement.click();
+
+    expect(mockOnReset).toHaveBeenCalledTimes(1);
+  });
+
+  // スタイルが正しく適用されていることを確認
+  it('has the correct frame class', () => {
+    const { container } = render(<CheckedManageFrame checkedSum={5} onReset={mockOnReset} />);
+    const frameElement = container.querySelector('div');
+    expect(frameElement).toHaveClass(styles.frame);
+  });
+});

--- a/src/components/molecules/CheckedManageFrame/CheckedManageFrame.tsx
+++ b/src/components/molecules/CheckedManageFrame/CheckedManageFrame.tsx
@@ -1,0 +1,18 @@
+import Button from '@/components/atoms/Button/Button';
+import Typography from '@/components/atoms/Typography/Typography';
+import styles from './CheckedManageFrame.module.scss';
+import { CheckedManageFrameProps } from './CheckedManageFrame.types';
+
+const CheckedManageFrame: React.FC<CheckedManageFrameProps> = ({ checkedSum, onReset }) => {
+  const frameStyle = `${styles.frame}`;
+  const isButtonDisabled = checkedSum <= 0;
+
+  return (
+    <div className={frameStyle}>
+      <Typography text={`選択件数：${checkedSum}件`} />
+      <Button label='選択解除' onClick={onReset} disabled={isButtonDisabled} />
+    </div>
+  );
+};
+
+export default CheckedManageFrame;

--- a/src/components/molecules/CheckedManageFrame/CheckedManageFrame.types.ts
+++ b/src/components/molecules/CheckedManageFrame/CheckedManageFrame.types.ts
@@ -1,0 +1,4 @@
+export interface CheckedManageFrameProps {
+  checkedSum: number;
+  onReset: () => void;
+}

--- a/src/components/molecules/Header/Header.test.tsx
+++ b/src/components/molecules/Header/Header.test.tsx
@@ -8,7 +8,7 @@ describe('Header Component', () => {
   it('renders with the given title', () => {
     render(<Header title='Test Title' />);
     const titleElement = screen.getByText(/Test Title/i);
-    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).toBeVisible();
   });
 
   // Headerのスタイルが正しく適用されていることを確認


### PR DESCRIPTION
## チケット

closes #26 

## 概要

選択件数と選択をリセットするボタンをまとめたコンポーネントを作成。

## 変更点・機能追加

### 選択件数・リセットボタンを含むFrameコンポーネントを作成

選択に関する情報をUI上でまとめる。
選択件数が0件の場合は、リセットボタンをdisabledにする。

### `toBeInTheDocument` → `toBeVisible`への変更

要素の可視性まで確認したいため。

各コンポーネントに使用している

## テスト内容

- [x] checkedSumが0より大きい場合に期待する動作がされるか
- [x]  checkedSumが0の場合
- [x] ボタンがクリックされたときにonResetが呼ばれること
- [x]  スタイルが正しく適用されていることを確認

## 確認事項

- [x] 上記テストがPASSすること
- [x] atoms/のテストも実行（※`toBeInTheDocument` → `toBeVisible`への変更に影響が無いか確認）

## 参考文献
**【Qiita】要素があるかどうかのテストにtoBeInTheDocumentを使っていませんか？**
https://qiita.com/kawabata324/items/39c2c4eedc94151c191f