### PR TITLE
CheckboxGroupコンポーネントの作成/Storyの作成/テスト実行

### DIFF
--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.module.scss
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.module.scss
@@ -1,0 +1,10 @@
+@use '../../../styles/variables/spacing' as spacing;
+@use '../../../styles/variables/colors' as color;
+
+.checkboxGroup {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(6rem, 1fr));
+  row-gap: spacing.$xs;
+  padding: spacing.$sm;
+  background-color: color.$background-white;
+}

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<CheckboxGroupProps> = {
   title: 'molecules/CheckboxGroup',
   component: CheckboxGroup,
   tags: ['autodocs'],
-  args: { setCheckedList: fn() },
+  args: { handleCheck: fn() },
 };
 
 export default meta;

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,0 +1,41 @@
+import { fn } from '@storybook/test';
+import CheckboxGroup from './CheckboxGroup';
+import { CheckboxGroupProps } from './CheckboxGroup.types';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<CheckboxGroupProps> = {
+  title: 'molecules/CheckboxGroup',
+  component: CheckboxGroup,
+  tags: ['autodocs'],
+  args: { setCheckedList: fn() },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const demoPrefectures = [
+  { prefCode: 1, prefName: '北海道' },
+  { prefCode: 2, prefName: '青森県' },
+  { prefCode: 3, prefName: '岩手県' },
+  { prefCode: 4, prefName: '宮城県' },
+  { prefCode: 5, prefName: '秋田県' },
+  { prefCode: 6, prefName: '山形県' },
+  { prefCode: 7, prefName: '福島県' },
+  { prefCode: 8, prefName: '茨城県' },
+  { prefCode: 9, prefName: '栃木県' },
+  { prefCode: 10, prefName: '群馬県' },
+  { prefCode: 11, prefName: '埼玉県' },
+  { prefCode: 12, prefName: '千葉県' },
+  { prefCode: 13, prefName: '東京都' },
+  { prefCode: 14, prefName: '神奈川県' },
+];
+
+export const Primary: Story = {
+  args: {
+    prefectures: demoPrefectures,
+    checkedList: [
+      { prefCode: 3, prefName: '岩手県' },
+      { prefCode: 4, prefName: '宮城県' },
+    ],
+  },
+};

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Prefecture } from '@/types';
+import CheckboxGroup from './CheckboxGroup';
+import '@testing-library/jest-dom';
+
+const prefectures: Prefecture[] = [
+  { prefCode: 1, prefName: '北海道' },
+  { prefCode: 2, prefName: '青森県' },
+  { prefCode: 3, prefName: '岩手県' },
+];
+
+describe('CheckboxGroup Component', () => {
+  const mockSetCheckedList = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // CheckboxGroupをレンダリングするヘルパー関数
+  const renderCheckboxGroup = (checkedList: Prefecture[] = []) => {
+    render(
+      <CheckboxGroup
+        prefectures={prefectures}
+        checkedList={checkedList}
+        setCheckedList={mockSetCheckedList}
+      />
+    );
+  };
+
+  // 各都道府県のチェックボックスが正しくレンダリングされているか確認
+  it('renders checkboxes for each prefecture', () => {
+    renderCheckboxGroup();
+    prefectures.forEach(({ prefName }) => {
+      expect(screen.getByLabelText(prefName)).toBeInTheDocument();
+    });
+  });
+
+  // 北海道のチェックボックスをクリックしてsetCheckedListが正しい値で呼び出されたか確認
+  it('calls setCheckedList with correct values when checkbox is checked', () => {
+    renderCheckboxGroup();
+    fireEvent.click(screen.getByLabelText('北海道'));
+    expect(mockSetCheckedList).toHaveBeenCalledWith([{ prefCode: 1, prefName: '北海道' }]);
+  });
+
+  // 北海道がチェックされた状態でCheckboxGroupをレンダリングし
+  // 北海道のチェックボックスをクリックしてチェックを外す
+  // setCheckedListが空の配列で呼び出されたか確認
+  it('calls setCheckedList to remove the prefecture when checkbox is unchecked', () => {
+    renderCheckboxGroup([{ prefCode: 1, prefName: '北海道' }]);
+    fireEvent.click(screen.getByLabelText('北海道'));
+    expect(mockSetCheckedList).toHaveBeenCalledWith([]);
+  });
+
+  // 北海道がチェックされている状態でCheckboxGroupをレンダリング
+  // 北海道がチェックされていて、青森県がチェックされていないことを確認
+  it('correctly reflects checked state of checkboxes', () => {
+    renderCheckboxGroup([{ prefCode: 1, prefName: '北海道' }]);
+
+    const checkedCheckbox = screen.getByLabelText('北海道');
+    const uncheckedCheckbox = screen.getByLabelText('青森県');
+
+    expect(checkedCheckbox).toBeChecked();
+    expect(uncheckedCheckbox).not.toBeChecked();
+  });
+});

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.test.tsx
@@ -10,7 +10,7 @@ const prefectures: Prefecture[] = [
 ];
 
 describe('CheckboxGroup Component', () => {
-  const mockSetCheckedList = jest.fn();
+  const mockHandleCheck = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -22,7 +22,7 @@ describe('CheckboxGroup Component', () => {
       <CheckboxGroup
         prefectures={prefectures}
         checkedList={checkedList}
-        setCheckedList={mockSetCheckedList}
+        handleCheck={mockHandleCheck}
       />
     );
   };
@@ -31,24 +31,24 @@ describe('CheckboxGroup Component', () => {
   it('renders checkboxes for each prefecture', () => {
     renderCheckboxGroup();
     prefectures.forEach(({ prefName }) => {
-      expect(screen.getByLabelText(prefName)).toBeInTheDocument();
+      expect(screen.getByLabelText(prefName)).toBeVisible();
     });
   });
 
-  // 北海道のチェックボックスをクリックしてsetCheckedListが正しい値で呼び出されたか確認
-  it('calls setCheckedList with correct values when checkbox is checked', () => {
+  // 北海道のチェックボックスをクリックしてhandleCheckが正しい値で呼び出されたか確認
+  it('calls handleCheck with correct values when checkbox is checked', () => {
     renderCheckboxGroup();
     fireEvent.click(screen.getByLabelText('北海道'));
-    expect(mockSetCheckedList).toHaveBeenCalledWith([{ prefCode: 1, prefName: '北海道' }]);
+    expect(mockHandleCheck).toHaveBeenCalledWith({ prefCode: 1, prefName: '北海道' });
   });
 
   // 北海道がチェックされた状態でCheckboxGroupをレンダリングし
   // 北海道のチェックボックスをクリックしてチェックを外す
-  // setCheckedListが空の配列で呼び出されたか確認
-  it('calls setCheckedList to remove the prefecture when checkbox is unchecked', () => {
+  // handleCheckが再び呼び出されるか確認
+  it('calls handleCheck to remove the prefecture when checkbox is unchecked', () => {
     renderCheckboxGroup([{ prefCode: 1, prefName: '北海道' }]);
     fireEvent.click(screen.getByLabelText('北海道'));
-    expect(mockSetCheckedList).toHaveBeenCalledWith([]);
+    expect(mockHandleCheck).toHaveBeenCalledWith({ prefCode: 1, prefName: '北海道' });
   });
 
   // 北海道がチェックされている状態でCheckboxGroupをレンダリング
@@ -58,7 +58,6 @@ describe('CheckboxGroup Component', () => {
 
     const checkedCheckbox = screen.getByLabelText('北海道');
     const uncheckedCheckbox = screen.getByLabelText('青森県');
-
     expect(checkedCheckbox).toBeChecked();
     expect(uncheckedCheckbox).not.toBeChecked();
   });

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.tsx
@@ -1,24 +1,10 @@
 import Checkbox from '@/components/atoms/Checkbox/Checkbox';
-import { Prefecture } from '@/types';
 import styles from './CheckboxGroup.module.scss';
 import { CheckboxGroupProps } from './CheckboxGroup.types';
 
-const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
-  prefectures,
-  checkedList,
-  setCheckedList,
-}) => {
+const CheckboxGroup: React.FC<CheckboxGroupProps> = ({ prefectures, checkedList, handleCheck }) => {
   const isChecked = (id: number) => {
     return checkedList.some((element) => element.prefCode === id);
-  };
-
-  const handleCheck = (prefecture: Prefecture) => {
-    const code = prefecture.prefCode;
-    if (isChecked(prefecture.prefCode)) {
-      setCheckedList(checkedList.filter((element) => element.prefCode !== code));
-    } else {
-      setCheckedList([...checkedList, ...[prefecture]]);
-    }
   };
 
   return (

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.tsx
@@ -1,0 +1,39 @@
+import Checkbox from '@/components/atoms/Checkbox/Checkbox';
+import { Prefecture } from '@/types';
+import styles from './CheckboxGroup.module.scss';
+import { CheckboxGroupProps } from './CheckboxGroup.types';
+
+const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
+  prefectures,
+  checkedList,
+  setCheckedList,
+}) => {
+  const isChecked = (id: number) => {
+    return checkedList.some((element) => element.prefCode === id);
+  };
+
+  const handleCheck = (prefecture: Prefecture) => {
+    const code = prefecture.prefCode;
+    if (isChecked(prefecture.prefCode)) {
+      setCheckedList(checkedList.filter((element) => element.prefCode !== code));
+    } else {
+      setCheckedList([...checkedList, ...[prefecture]]);
+    }
+  };
+
+  return (
+    <div className={styles.checkboxGroup}>
+      {prefectures.map((prefecture) => (
+        <Checkbox
+          key={prefecture.prefCode}
+          id={String(prefecture.prefCode)}
+          label={prefecture.prefName}
+          checked={isChecked(prefecture.prefCode)}
+          onChange={() => handleCheck(prefecture)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CheckboxGroup;

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.types.ts
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.types.ts
@@ -3,5 +3,5 @@ import { Prefecture } from '@/types';
 export interface CheckboxGroupProps {
   prefectures: Prefecture[];
   checkedList: Prefecture[];
-  setCheckedList: React.Dispatch<React.SetStateAction<Prefecture[]>>;
+  handleCheck: (prefecture: Prefecture) => void;
 }

--- a/src/components/molecules/CheckboxGroup/CheckboxGroup.types.ts
+++ b/src/components/molecules/CheckboxGroup/CheckboxGroup.types.ts
@@ -1,0 +1,7 @@
+import { Prefecture } from '@/types';
+
+export interface CheckboxGroupProps {
+  prefectures: Prefecture[];
+  checkedList: Prefecture[];
+  setCheckedList: React.Dispatch<React.SetStateAction<Prefecture[]>>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+export interface Prefecture {
+  prefCode: number;
+  prefName: string;
+}


### PR DESCRIPTION
## チケット

closes #27 

## 概要

都道府県を選択するチェックボックスを並べるコンポーネントを作成。
Grid表示をすることでウィンドウサイズに柔軟に対応

## 変更点・機能追加

### `Checkbox`をGridで表示

取得した都道府県情報をmap関数で展開し、atoms/で作成した`Checkbox`コンポーネントをGrid表示する。

### テスト内容

- [x] 各都道府県のチェックボックスが正しくレンダリングされているか
- [x] setCheckedListが正しい値で呼び出されるか
- [x] チェックボックスの挙動と結果が相違ないこと
- [x] 任意のチェックボックスの操作が他のチェックボックスに影響が無いこと

## 確認事項

- [x] 上記のテストがPASSすること