### PR TITLE
PopulationTabGroupコンポーネントを作成

### DIFF
--- a/src/components/molecules/PopulationTabGroup/PopulationTabGroup.module.scss
+++ b/src/components/molecules/PopulationTabGroup/PopulationTabGroup.module.scss
@@ -1,0 +1,9 @@
+@use '../../../styles/variables/colors' as color;
+@use '../../../styles/variables/spacing' as spacing;
+
+.tabGroup {
+  display: flex;
+  overflow-x: auto;
+  white-space: nowrap;
+  border-bottom: spacing.$min solid color.$primary-main;
+}

--- a/src/components/molecules/PopulationTabGroup/PopulationTabGroup.stories.tsx
+++ b/src/components/molecules/PopulationTabGroup/PopulationTabGroup.stories.tsx
@@ -1,0 +1,28 @@
+import { fn } from '@storybook/test';
+import { PopulationTabDefs } from '@/consts/PopulationTabDefs';
+import PopulationTabGroup from './PopulationTabGroup';
+import { PopulationTabGroupProps, PopulationTabId } from './PopulationTabGroup.types';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<PopulationTabGroupProps> = {
+  title: 'molecules/PopulationTabGroup',
+  component: PopulationTabGroup,
+  tags: ['autodocs'],
+  args: { onClick: fn() },
+  argTypes: {
+    selected: {
+      options: Object.values(PopulationTabId),
+      control: 'select',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    tabs: PopulationTabDefs,
+    selected: PopulationTabId.TotalPopulation,
+  },
+};

--- a/src/components/molecules/PopulationTabGroup/PopulationTabGroup.tsx
+++ b/src/components/molecules/PopulationTabGroup/PopulationTabGroup.tsx
@@ -1,0 +1,20 @@
+import Tab from '@/components/atoms/Tab/Tab';
+import styles from './PopulationTabGroup.module.scss';
+import { PopulationTabGroupProps } from './PopulationTabGroup.types';
+
+const PopulationTabGroup: React.FC<PopulationTabGroupProps> = ({ tabs, selected, onClick }) => {
+  return (
+    <div className={styles.tabGroup}>
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.id}
+          label={tab.label}
+          selected={selected === tab.id}
+          onClick={() => onClick(tab.id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default PopulationTabGroup;

--- a/src/components/molecules/PopulationTabGroup/PopulationTabGroup.types.ts
+++ b/src/components/molecules/PopulationTabGroup/PopulationTabGroup.types.ts
@@ -1,0 +1,17 @@
+export enum PopulationTabId {
+  TotalPopulation = 'totalPopulation',
+  YouthPopulation = 'youthPopulation',
+  WorkingAgePopulation = 'workingAgePopulation',
+  ElderlyPopulation = 'elderlyPopulation',
+}
+
+export interface PopulationTab {
+  id: PopulationTabId;
+  label: string;
+}
+
+export interface PopulationTabGroupProps {
+  tabs: PopulationTab[];
+  selected: PopulationTabId;
+  onClick: (id: PopulationTabId) => void;
+}

--- a/src/components/molecules/PopulationTabGroup/PopulationtabGrout.test.tsx
+++ b/src/components/molecules/PopulationTabGroup/PopulationtabGrout.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { PopulationTabDefs } from '@/consts/PopulationTabDefs';
+import PopulationTabGroup from './PopulationTabGroup';
+import { PopulationTabId } from './PopulationTabGroup.types';
+import '@testing-library/jest-dom';
+
+describe('PopulationTabGroup Component', () => {
+  const mockOnClick = jest.fn();
+
+  // PopulationTabGroupをレンダリングするヘルパー関数
+  const renderComponent = (selected: PopulationTabId) => {
+    return render(
+      <PopulationTabGroup tabs={PopulationTabDefs} selected={selected} onClick={mockOnClick} />
+    );
+  };
+
+  // タブが正しく表示されることを確認
+  it('renders the correct tabs', () => {
+    renderComponent(PopulationTabId.TotalPopulation);
+    PopulationTabDefs.forEach((tab) => {
+      const tabElement = screen.getByRole('button', { name: tab.label });
+      expect(tabElement).toBeVisible();
+    });
+  });
+
+  // 選択されているタブが正しくスタイルされていることを確認
+  it('applies selected style to the active tab', () => {
+    renderComponent(PopulationTabId.TotalPopulation);
+    const selectedTabElement = screen.getByRole('button', { name: '総人口' });
+    expect(selectedTabElement).toHaveClass('selected');
+  });
+
+  // タブがクリックされたときにonClickが呼ばれることを確認
+  it('calls onClick when a tab is clicked', () => {
+    renderComponent(PopulationTabId.TotalPopulation);
+    const tabElement = screen.getByRole('button', { name: '年少人口' });
+    tabElement.click();
+    expect(mockOnClick).toHaveBeenCalledWith(PopulationTabId.YouthPopulation);
+  });
+});

--- a/src/consts/PopulationTabDefs.ts
+++ b/src/consts/PopulationTabDefs.ts
@@ -1,0 +1,23 @@
+import {
+  PopulationTab,
+  PopulationTabId,
+} from '@/components/molecules/PopulationTabGroup/PopulationTabGroup.types';
+
+export const PopulationTabDefs: PopulationTab[] = [
+  {
+    id: PopulationTabId.TotalPopulation,
+    label: '総人口',
+  },
+  {
+    id: PopulationTabId.YouthPopulation,
+    label: '年少人口',
+  },
+  {
+    id: PopulationTabId.WorkingAgePopulation,
+    label: '生産年齢人口',
+  },
+  {
+    id: PopulationTabId.ElderlyPopulation,
+    label: '老年人口',
+  },
+];


### PR DESCRIPTION
## チケット

ref #24 
closes #28 

## 概要

「総人口」「年少人口」「生産年齢人口」「老年人口」を切り替えるタブをまとめたコンポーネントを作成。

## 変更点・機能追加

### Tabコンポーネントをマップで展開

`atoms/`で作成した`Tab`コンポーネントをマップで展開して横に並べる。
タブの情報は、以下のようにconsts/PopulationTabDefs.tsへ記述。

```PopulationTabDefs.ts
export const PopulationTabDefs: PopulationTab[] = [
  {
    id: PopulationTabId.TotalPopulation,
    label: '総人口',
  },
  {
    id: PopulationTabId.YouthPopulation,
    label: '年少人口',
  },
  {
    id: PopulationTabId.WorkingAgePopulation,
    label: '生産年齢人口',
  },
  {
    id: PopulationTabId.ElderlyPopulation,
    label: '老年人口',
  },
];
```

また、モバイルの幅でも基本的に問題なく動作するが、
```css
  overflow-x: auto;
  white-space: nowrap;
```
のスタイルを付与して、スクロール可能にしている。

## テスト内容

- [x] タブが正しく表示されること
- [x] 選択されているタブが正しくスタイルされていること
- [x] タブがクリックされたときにonClickが呼ばれること

## 確認事項

- [x] 上記テストがPASSすること
- [x] ウィンドウの横幅を狭めた時にスクロールバーが出現しすべてのタブが押下できること 