### PR TITLE
PopulationTrendGraphコンポーネント作成/Story作成/テスト実行

### DIFF
--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -26,3 +26,4 @@ jobs:
       - run: npm run test:atoms
       - run: npm run test:molecules
       - run: npm run test:organisms
+      - run: npm run test:templates

--- a/jest.templates.config.ts
+++ b/jest.templates.config.ts
@@ -1,0 +1,12 @@
+import nextJest from 'next/jest';
+import createConfig from './jest/createConfig';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const atomComponentJestConfig = {
+  ...createConfig('templates'),
+};
+
+export default createJestConfig(atomComponentJestConfig);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:atoms": "jest --config jest.atoms.config.ts",
     "test:molecules": "jest --config jest.molecules.config.ts",
     "test:organisms": "jest --config jest.organisms.config.ts",
+    "test:templates": "jest --config jest.templates.config.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,6 @@
+import Header from '@/components/molecules/Header/Header';
 import '../styles/globals.scss';
+import { metaData } from '@/consts/appMeta';
 
 export default function RootLayout({
   children,
@@ -7,7 +9,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ja'>
-      <body>{children}</body>
+      <head>
+        <title>{metaData.title}</title>
+        <meta name='description' content={metaData.description} />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <meta charSet='utf-8' />
+      </head>
+      <body>
+        <header>
+          <Header title={metaData.title} />
+        </header>
+        <main>{children}</main>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,5 @@
-export default function Home() {}
+import PopulationTrendGraph from '@/components/templates/PopulationTrendGraph/PopulationTrendGraph';
+
+export default function Home() {
+  return <PopulationTrendGraph />;
+}

--- a/src/components/molecules/Header/Header.module.scss
+++ b/src/components/molecules/Header/Header.module.scss
@@ -3,7 +3,7 @@
 
 .header {
   background-color: color.$primary-main;
-  width: 100vw;
+  width: 100%;
   display: flex;
   justify-content: center;
   padding: spacing.$xs;

--- a/src/components/molecules/PopulationGraph/PopulationGraph.tsx
+++ b/src/components/molecules/PopulationGraph/PopulationGraph.tsx
@@ -6,8 +6,8 @@ import {
   CartesianGrid,
   XAxis,
   YAxis,
-  Tooltip,
   Legend,
+  Tooltip,
 } from 'recharts';
 import { PrefectureGraphData } from '@/components/organisms/PopulationGraphFrame/PopulationGraphFrame.types';
 import { getColor } from '@/utils/getColor';
@@ -29,7 +29,7 @@ const PopulationGraph: React.FC<PopulationGraphProps> = ({ populationData, tabVa
   return (
     <div className={styles.graph} data-testid='population-graph'>
       <ResponsiveContainer>
-        <LineChart data={graphData} margin={{ top: 40, right: 60, left: 10, bottom: 30 }}>
+        <LineChart data={graphData} margin={{ top: 40, right: 60, left: 0, bottom: 30 }}>
           {graphDataWithoutYear.map((key, index) => (
             <Line
               key={key}

--- a/src/components/molecules/PrefCheckboxGroup/PrefCheckboxGroup.module.scss
+++ b/src/components/molecules/PrefCheckboxGroup/PrefCheckboxGroup.module.scss
@@ -4,7 +4,6 @@
 .checkboxGroup {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(6rem, 1fr));
-  row-gap: spacing.$xs;
   padding: spacing.$sm;
   background-color: color.$background-white;
   overflow: auto;

--- a/src/components/organisms/PopulationGraphFrame/PopulationGraphFrame.module.scss
+++ b/src/components/organisms/PopulationGraphFrame/PopulationGraphFrame.module.scss
@@ -1,6 +1,16 @@
 @use '../../../styles/variables/colors' as color;
+@use '../../../styles/variables/spacing' as spacing;
+@use '../../../styles/mixins/respond-to-mobile' as respond-to-mobile;
+
+.container {
+  padding: spacing.$md 0;
+}
 
 .graphFrame {
   width: 100%;
   height: 50vh;
+
+  @include respond-to-mobile.respond-to-mobile {
+    height: 40vh;
+  }
 }

--- a/src/components/organisms/PopulationGraphFrame/PopulationGraphFrame.tsx
+++ b/src/components/organisms/PopulationGraphFrame/PopulationGraphFrame.tsx
@@ -25,13 +25,15 @@ const PopulationGraphFrame: React.FC<PrefectureGraphProps> = ({ prefectures }) =
   }, [prefectures]);
 
   return (
-    <div className={styles.graphFrame}>
-      <PopulationTabGroup
-        tabs={populationTabDefs}
-        selected={selectedTab}
-        onClick={setSelectedTab}
-      />
-      <PopulationGraph populationData={populationData} tabValue={selectedTab} />
+    <div className={styles.container}>
+      <div className={styles.graphFrame}>
+        <PopulationTabGroup
+          tabs={populationTabDefs}
+          selected={selectedTab}
+          onClick={setSelectedTab}
+        />
+        <PopulationGraph populationData={populationData} tabValue={selectedTab} />
+      </div>
     </div>
   );
 };

--- a/src/components/organisms/PrefSelectionFrame/PrefSelectionFrame.module.scss
+++ b/src/components/organisms/PrefSelectionFrame/PrefSelectionFrame.module.scss
@@ -1,5 +1,9 @@
 @use '../../../styles/variables/spacing' as spacing;
 
+.container {
+  padding: spacing.$md 0;
+}
+
 .frameHeader {
   display: flex;
   justify-content: space-between;

--- a/src/components/organisms/PrefSelectionFrame/PrefSelectionFrame.tsx
+++ b/src/components/organisms/PrefSelectionFrame/PrefSelectionFrame.tsx
@@ -25,13 +25,13 @@ const PrefSelectionFrame: React.FC<PrefSelectionFrameProps> = ({
   };
 
   return (
-    <>
+    <div className={styles.container}>
       <div className={styles.frameHeader}>
         <TextLabel label='都道府県を選択' />
         <CheckedManageFrame checkedSum={checkedPrefectures.length} onReset={handleReset} />
       </div>
       <PrefCheckboxGroup checkedList={checkedPrefectures} handleCheck={handleCheck} />
-    </>
+    </div>
   );
 };
 

--- a/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.module.scss
+++ b/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.module.scss
@@ -1,0 +1,8 @@
+@use '../../../styles/variables/spacing' as spacing;
+@use '../../../styles/variables/breakpoint' as breakpoint;
+
+.container {
+  max-width: breakpoint.$max-width;
+  padding: spacing.$lg;
+  margin: 0 auto spacing.$lg auto;
+}

--- a/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.stories.tsx
+++ b/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import PopulationTrendGraph from './PopulationTrendGraph';
+
+const meta: Meta = {
+  title: 'templates/PopulationTrendGraph',
+  component: PopulationTrendGraph,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  render: () => (
+    <div style={{ padding: '20px' }}>
+      <PopulationTrendGraph />
+    </div>
+  ),
+};

--- a/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.test.tsx
+++ b/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import useFetchPrefecture from '@/hooks/useFetchPrefecture';
+import PopulationTrendGraph from './PopulationTrendGraph';
+import '@testing-library/jest-dom';
+
+// ResizeObserverをモック
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+jest.mock('recharts', () => {
+  const OriginalModule = jest.requireActual('recharts');
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: '800px', height: '400px' }}>{children}</div>
+    ),
+  };
+});
+
+jest.mock('../../../hooks/useFetchPrefecture');
+
+describe('PopulationTrendGraph Component', () => {
+  beforeEach(() => {
+    (useFetchPrefecture as jest.Mock).mockReturnValue({
+      prefectures: [
+        { prefCode: 1, prefName: '北海道' },
+        { prefCode: 2, prefName: '青森県' },
+        { prefCode: 3, prefName: '岩手県' },
+      ],
+      isError: false,
+      isLoading: false,
+    });
+    jest.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  // コンポーネントが正しくレンダリングされることを確認
+  it('renders the component with PrefSelectionFrame and PopulationGraphFrame', async () => {
+    await act(async () => {
+      render(<PopulationTrendGraph />);
+    });
+    expect(screen.getByText('都道府県を選択')).toBeVisible();
+    expect(screen.getByText('選択件数：0件')).toBeVisible();
+  });
+
+  describe('Checkbox interactions', () => {
+    // チェックボックスがクリックされたときに新しい都道府県が追加されることを確認
+    it('adds a new prefecture when an unchecked checkbox is clicked', async () => {
+      await act(async () => {
+        render(<PopulationTrendGraph />);
+      });
+      const newCheckbox = screen.getByLabelText('岩手県');
+      await act(async () => {
+        fireEvent.click(newCheckbox);
+      });
+      // 選択件数が1件に増加したことを確認
+      expect(screen.getByText('選択件数：1件')).toBeVisible();
+    });
+
+    // すでにチェックされているチェックボックスがクリックされたときに、選択が解除されることを確認
+    it('removes a prefecture when an already checked checkbox is clicked', async () => {
+      await act(async () => {
+        render(<PopulationTrendGraph />);
+      });
+      const checkbox = screen.getByLabelText('北海道');
+      await act(async () => {
+        fireEvent.click(checkbox);
+      });
+
+      await act(async () => {
+        fireEvent.click(checkbox);
+      });
+      expect(screen.getByText('選択件数：0件')).toBeVisible();
+    });
+
+    // リセットボタンがクリックされたときに、選択が全て解除されることを確認
+    it('calls setCheckedPrefectures with an empty array when reset is clicked', async () => {
+      await act(async () => {
+        render(<PopulationTrendGraph />);
+      });
+      const resetButton = screen.getByRole('button', { name: '選択解除' });
+      await act(async () => {
+        fireEvent.click(resetButton);
+      });
+      expect(screen.getByText('選択件数：0件')).toBeVisible();
+    });
+  });
+});

--- a/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.tsx
+++ b/src/components/templates/PopulationTrendGraph/PopulationTrendGraph.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import PopulationGraphFrame from '@/components/organisms/PopulationGraphFrame/PopulationGraphFrame';
+import PrefSelectionFrame from '@/components/organisms/PrefSelectionFrame/PrefSelectionFrame';
+import { Prefecture } from '@/types/resas';
+import styles from './PopulationTrendGraph.module.scss';
+
+const PopulationTrendGraph = () => {
+  const [checkedPrefectures, setCheckedPrefectures] = useState<Prefecture[]>([]);
+
+  return (
+    <div className={styles.container}>
+      <PrefSelectionFrame
+        checkedPrefectures={checkedPrefectures}
+        setCheckedPrefectures={setCheckedPrefectures}
+      />
+      <PopulationGraphFrame prefectures={checkedPrefectures} />
+    </div>
+  );
+};
+
+export default PopulationTrendGraph;

--- a/src/consts/appMeta.ts
+++ b/src/consts/appMeta.ts
@@ -1,0 +1,5 @@
+export const metaData = {
+  description:
+    'RESAS_APIを使用して、選択した都道府県に対しての人口構成をグラフ上で描画するアプリです。',
+  title: '都道府県別人口構成グラフ',
+};

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -66,7 +66,3 @@ button {
   cursor: pointer;
   border: none;
 }
-
-.container {
-  padding: 20px;
-}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -66,3 +66,7 @@ button {
   cursor: pointer;
   border: none;
 }
+
+.container {
+  padding: 20px;
+}

--- a/src/styles/variables/_breakpoint.scss
+++ b/src/styles/variables/_breakpoint.scss
@@ -1,2 +1,2 @@
 $mobile: 480px;
-$max-width: 1280px;
+$max-width: 1080px;


### PR DESCRIPTION
## チケット

closes #44 

## 概要

`PopulationGraphFrame`, `PrefSelectionFrame`コンポーネントを組み合わせて、`PopulationTrendGraph`コンポーネントを作成。
page.tsxにこの`PopulationTrendGraph`コンポーネントをインポートして画面に表示するところまで実装。
`Header`をlayout.tsxでインポートして使用。
Story、テストを作成。

## 変更点・機能追加

### `PopulationTrendGraph`コンポーネントを作成

`PopulationGraphFrame`, `PrefSelectionFrame`コンポーネントを組み合わせて作成。
`max-width : breakpoint.$max-width`を指定して、横幅の広いウィンドウに対しても、UIを一定化。
都道府県の選択で縦にスクロールするので、都道府県選択とグラフ閲覧時は、なるべく全体のスクロールが少なく済むように、`PopulationGraphFrame`, `PrefSelectionFrame`コンポーネントのそれぞれの`max-height`を調整。

### storyとテストの作成

Storyを作成して、UIの確認を行う。
organismsと重なる点が多いが、テストを作成して実行。
CIの設定にも追加済み。

## テスト内容

- [x] コンポーネントが正しくレンダリングされること
- [x] チェックボックスがクリックされたときに新しい都道府県が追加されること
- [x] すでにチェックされているチェックボックスがクリックされた際に選択が解除されること
- [x] リセットボタンが有効であること 

## 確認事項

- [x] 上記テストがPASSすること
- [x] 実際に画面上で手動チェック
- [x] レスポンシブ対応が出てきているか :warning:

## スクリーンショット

<details><summary>:sparkles:おおまかな完成画面</summary>
<p>

![完成図](https://github.com/user-attachments/assets/85a5cf3c-b1f0-45c2-9df5-25f730984a32)

</p>
</details> 

## :wrench:リファクタ依頼

<details><summary>レスポンシブ周り</summary>
<p>

**レスポンシブでUI崩れがある箇所**
![レスポンシブでUI崩れがある箇所](https://github.com/user-attachments/assets/fb638401-9039-42af-b1f6-f58a5f16dbbe)

</p>
</details> 

<details><summary>都道府県未選択時のふるまい</summary>
<p>

**都道府県未選択時のふるまい**
![都道府県未選択時のふるまい](https://github.com/user-attachments/assets/dd927ca9-7864-40a3-ac50-ecc90be55020)

</p>
</details> 

## 参考文献
**RechartsのテストがJestでできないIssue**
https://github.com/recharts/recharts/issues/2982

## その他の共有事項
**:ballot_box_with_check: 残作業**
- 全体を通したリファクタのチケットを立てる
- Vercelにデプロイ